### PR TITLE
Adding in start inventory from pool and get filler item name, changing option tooltip displays, fix slot bleed

### DIFF
--- a/worlds/inscryption/Options.py
+++ b/worlds/inscryption/Options.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass
 
-from Options import Toggle, Choice, DeathLinkMixin, PerGameCommonOptions
+from Options import Toggle, Choice, DeathLinkMixin, StartInventoryPool, PerGameCommonOptions
 
 
 class Act1DeathLinkBehaviour(Choice):
     """If DeathLink is enabled, determines what counts as a death in act 1. This affects deaths sent and received.
-    Sacrificed: Send a death when sacrificed by Leshy. Receiving a death will extinguish all candles.
-    Candle Extinguished: Send a death when a candle is extinguished. Receiving a death will extinguish a candle."""
+
+    - Sacrificed: Send a death when sacrificed by Leshy. Receiving a death will extinguish all candles.
+
+    - Candle Extinguished: Send a death when a candle is extinguished. Receiving a death will extinguish a candle."""
     display_name = "Act 1 Death Link Behaviour"
     option_sacrificed = 0
     option_candle_extinguished = 1
@@ -14,9 +16,12 @@ class Act1DeathLinkBehaviour(Choice):
 
 class Goal(Choice):
     """Defines the goal to accomplish in order to complete the randomizer.
-    Full Story In Order: Complete each act in order. You can return to previously completed acts.
-    Full Story Any Order: Complete each act in any order. All acts are available from the start.
-    First Act: Complete Act 1 by finding the New Game button. Great for a smaller scale randomizer."""
+
+    - Full Story In Order: Complete each act in order. You can return to previously completed acts.
+
+    - Full Story Any Order: Complete each act in any order. All acts are available from the start.
+
+    - First Act: Complete Act 1 by finding the New Game button. Great for a smaller scale randomizer."""
     display_name = "Goal"
     option_full_story_in_order = 0
     option_full_story_any_order = 1
@@ -31,9 +36,12 @@ class RandomizeCodes(Toggle):
 class RandomizeDeck(Choice):
     """Randomize cards in your deck into new cards.
     Disable: Disable the feature.
-    Every Encounter Within Same Type: Randomize cards within the same type every encounter (keep rarity/scrybe type).
-    Every Encounter Any Type: Randomize cards into any possible card every encounter.
-    Starting Only: Only randomize cards given at the beginning of runs and acts."""
+
+    - Every Encounter Within Same Type: Randomize cards within the same type every encounter (keep rarity/scrybe type).
+
+    - Every Encounter Any Type: Randomize cards into any possible card every encounter.
+
+    - Starting Only: Only randomize cards given at the beginning of runs and acts."""
     display_name = "Randomize Deck"
     option_disable = 0
     option_every_encounter_within_same_type = 1
@@ -43,9 +51,12 @@ class RandomizeDeck(Choice):
 
 class RandomizeSigils(Choice):
     """Randomize sigils printed on the cards into new sigils every encounter.
-    Disable: Disable the feature.
-    Randomize Addons: Only randomize sigils added from sacrifices or other means.
-    Randomize All: Randomize all sigils."""
+
+    - Disable: Disable the feature.
+
+    - Randomize Addons: Only randomize sigils added from sacrifices or other means.
+
+    - Randomize All: Randomize all sigils."""
     display_name = "Randomize Abilities"
     option_disable = 0
     option_randomize_addons = 1
@@ -54,9 +65,12 @@ class RandomizeSigils(Choice):
 
 class OptionalDeathCard(Choice):
     """Add a moment after death in act 1 where you can decide to create a death card or not.
-    Disable: Disable the feature.
-    Always on: The choice is always offered after losing all candles.
-    DeathLink Only: The choice is only offered after receiving a DeathLink event."""
+
+    - Disable: Disable the feature.
+
+    - Always On: The choice is always offered after losing all candles.
+
+    - DeathLink Only: The choice is only offered after receiving a DeathLink event."""
     display_name = "Optional Death Card"
     option_disable = 0
     option_always_on = 1
@@ -76,9 +90,12 @@ class SkipEpilogue(Toggle):
 
 class EpitaphPiecesRandomization(Choice):
     """Determines how epitaph pieces in act 2 are randomized. This can affect your chances of getting stuck.
-    All Pieces: Randomizes all nine pieces as their own item.
-    In Groups: Randomizes pieces in groups of three.
-    As One Item: Group all nine pieces as a single item."""
+
+    - All Pieces: Randomizes all nine pieces as their own item.
+
+    - In Groups: Randomizes pieces in groups of three.
+
+    - As One Item: Group all nine pieces as a single item."""
     display_name = "Epitaph Pieces Randomization"
     option_all_pieces = 0
     option_in_groups = 1
@@ -87,9 +104,12 @@ class EpitaphPiecesRandomization(Choice):
 
 class PaintingChecksBalancing(Choice):
     """Generation options for the second and third painting checks in act 1.
-    None: Adds no progression logic to these painting checks. They will all count as sphere 1 (early game checks).
-    Balanced: Adds rules to these painting checks. Early game items are less likely to appear into these paintings.
-    Force Filler: For when you dislike doing these last two paintings. Their checks will only contain filler items."""
+
+    - None: Adds no progression logic to these painting checks. They will all count as sphere 1 (early game checks).
+
+    - Balanced: Adds rules to these painting checks. Early game items are less likely to appear into these paintings.
+
+    - Force Filler: For when you dislike doing these last two paintings. Their checks will only contain filler items."""
     display_name = "Painting Checks Balancing"
     option_none = 0
     option_balanced = 1
@@ -98,6 +118,7 @@ class PaintingChecksBalancing(Choice):
 
 @dataclass
 class InscryptionOptions(DeathLinkMixin, PerGameCommonOptions):
+    start_inventory_from_pool: StartInventoryPool
     act1_death_link_behaviour: Act1DeathLinkBehaviour
     goal: Goal
     randomize_codes: RandomizeCodes

--- a/worlds/inscryption/__init__.py
+++ b/worlds/inscryption/__init__.py
@@ -45,41 +45,43 @@ class InscryptionWorld(World):
     options_dataclass = InscryptionOptions
     options: InscryptionOptions
     all_items = act1_items + act2_items + act3_items + filler_items
-    item_name_to_id = {item['name']: i + base_id for i, item in enumerate(all_items)}
+    item_name_to_id = {item["name"]: i + base_id for i, item in enumerate(all_items)}
     all_locations = act1_locations + act2_locations + act3_locations
     location_name_to_id = {location: i + base_id for i, location in enumerate(all_locations)}
     required_epitaph_pieces_count = 9
     required_epitaph_pieces_name = "Epitaph Piece"
 
     def generate_early(self) -> None:
-        if self.options.goal != Goal.option_first_act:
-            if self.options.epitaph_pieces_randomization == EpitaphPiecesRandomization.option_all_pieces:
-                self.required_epitaph_pieces_name = "Epitaph Piece"
-                self.required_epitaph_pieces_count = 9
-            elif self.options.epitaph_pieces_randomization == EpitaphPiecesRandomization.option_in_groups:
-                self.required_epitaph_pieces_name = "Epitaph Pieces"
-                self.required_epitaph_pieces_count = 3
-            else:
-                self.required_epitaph_pieces_name = "Epitaph Pieces"
-                self.required_epitaph_pieces_count = 1
+        if self.options.epitaph_pieces_randomization == EpitaphPiecesRandomization.option_all_pieces:
+            self.required_epitaph_pieces_name = "Epitaph Piece"
+            self.required_epitaph_pieces_count = 9
+        elif self.options.epitaph_pieces_randomization == EpitaphPiecesRandomization.option_in_groups:
+            self.required_epitaph_pieces_name = "Epitaph Pieces"
+            self.required_epitaph_pieces_count = 3
+        else:
+            self.required_epitaph_pieces_name = "Epitaph Pieces"
+            self.required_epitaph_pieces_count = 1
 
         if self.options.painting_checks_balancing == PaintingChecksBalancing.option_balanced:
-            act1_items[6]['classification'] = ItemClassification.progression
-            act1_items[11]['classification'] = ItemClassification.progression
+            act1_items[6]["classification"] = ItemClassification.progression
+            act1_items[11]["classification"] = ItemClassification.progression
         else:
-            act1_items[6]['classification'] = ItemClassification.useful
-            act1_items[11]['classification'] = ItemClassification.useful
+            act1_items[6]["classification"] = ItemClassification.useful
+            act1_items[11]["classification"] = ItemClassification.useful
 
         if self.options.painting_checks_balancing == PaintingChecksBalancing.option_force_filler \
                 and self.options.goal == Goal.option_first_act:
-            act1_items[3]['classification'] = ItemClassification.filler
+            act1_items[3]["classification"] = ItemClassification.filler
         else:
-            act1_items[3]['classification'] = ItemClassification.useful
+            act1_items[3]["classification"] = ItemClassification.useful
+
+    def get_filler_item_name(self) -> str:
+        return self.random.choice(filler_items)["name"]
 
     def create_item(self, name: str) -> Item:
         item_id = self.item_name_to_id[name]
         item_data = self.all_items[item_id - base_id]
-        return InscryptionItem(name, item_data['classification'], item_id, self.player)
+        return InscryptionItem(name, item_data["classification"], item_id, self.player)
 
     def create_items(self) -> None:
         nb_items_added = 0
@@ -91,14 +93,14 @@ class InscryptionWorld(World):
                 useful_items.remove(act2_items[3])
             elif self.options.epitaph_pieces_randomization == EpitaphPiecesRandomization.option_in_groups:
                 useful_items.remove(act2_items[2])
-                useful_items[len(act1_items) + 2]['count'] = 3
+                useful_items[len(act1_items) + 2]["count"] = 3
             else:
                 useful_items.remove(act2_items[2])
-                useful_items[len(act1_items) + 2]['count'] = 1
+                useful_items[len(act1_items) + 2]["count"] = 1
 
         for item in useful_items:
             for _ in range(item["count"]):
-                new_item = self.create_item(item['name'])
+                new_item = self.create_item(item["name"])
                 self.multiworld.itempool.append(new_item)
                 nb_items_added += 1
 
@@ -108,7 +110,7 @@ class InscryptionWorld(World):
         for i in range(filler_count):
             index = i % len(filler_items)
             filler_item = filler_items[index]
-            new_item = self.create_item(filler_item['name'])
+            new_item = self.create_item(filler_item["name"])
             self.multiworld.itempool.append(new_item)
 
     def create_regions(self) -> None:

--- a/worlds/inscryption/__init__.py
+++ b/worlds/inscryption/__init__.py
@@ -50,6 +50,8 @@ class InscryptionWorld(World):
     location_name_to_id = {location: i + base_id for i, location in enumerate(all_locations)}
     required_epitaph_pieces_count = 9
     required_epitaph_pieces_name = "Epitaph Piece"
+    act1_painting_reqs_progression = False
+    act1_skink_filler = False
 
     def generate_early(self) -> None:
         if self.options.epitaph_pieces_randomization == EpitaphPiecesRandomization.option_all_pieces:
@@ -63,17 +65,11 @@ class InscryptionWorld(World):
             self.required_epitaph_pieces_count = 1
 
         if self.options.painting_checks_balancing == PaintingChecksBalancing.option_balanced:
-            act1_items[6]["classification"] = ItemClassification.progression
-            act1_items[11]["classification"] = ItemClassification.progression
-        else:
-            act1_items[6]["classification"] = ItemClassification.useful
-            act1_items[11]["classification"] = ItemClassification.useful
+            self.act1_painting_reqs_progression = True
 
         if self.options.painting_checks_balancing == PaintingChecksBalancing.option_force_filler \
                 and self.options.goal == Goal.option_first_act:
-            act1_items[3]["classification"] = ItemClassification.filler
-        else:
-            act1_items[3]["classification"] = ItemClassification.useful
+            self.act1_skink_filler = True
 
     def get_filler_item_name(self) -> str:
         return self.random.choice(filler_items)["name"]
@@ -97,6 +93,13 @@ class InscryptionWorld(World):
             else:
                 useful_items.remove(act2_items[2])
                 useful_items[len(act1_items) + 2]["count"] = 1
+
+        if self.act1_painting_reqs_progression:
+            useful_items[6]["classification"] = ItemClassification.progression
+            useful_items[11]["classification"] = ItemClassification.progression
+
+        if self.act1_skink_filler:
+            useful_items[3]["classification"] = ItemClassification.filler
 
         for item in useful_items:
             for _ in range(item["count"]):

--- a/worlds/inscryption/__init__.py
+++ b/worlds/inscryption/__init__.py
@@ -82,7 +82,7 @@ class InscryptionWorld(World):
     def create_items(self) -> None:
         nb_items_added = 0
         useful_items = (act1_items + act2_items + act3_items) if self.options.goal != Goal.option_first_act \
-            else act1_items
+            else act1_items.copy()
 
         if self.options.goal != Goal.option_first_act:
             if self.options.epitaph_pieces_randomization == EpitaphPiecesRandomization.option_all_pieces:


### PR DESCRIPTION
## What is this fixing or adding?

Adds `get_filler_item_name` and `start_inventory_from_pool` to Inscryption.
Also changes the way that the option tooltips are displayed for greater readability.
Changed some single quotes in `__init__.py` to double quotes.
Removed an `if` clause in `init` because the epitaph piece counts and names don't matter if your goal _is_ Act 1 so checking that it isn't an Act 1 goal isn't needed.

Also discovered a bleeding issue where `act1_items` was being modified directly, which impacted it for all other worlds. Converted these to instead use variables and modify the per-world "useful_items" instead

## How was this tested?

Unit tests. Also 100 random single-player generations. Several generations testing that `start_inventory_from_pool` worked properly and added filler items as replacements.

## If this makes graphical changes, please attach screenshots.
![Previous display of option tooltips which had little spacing](https://github.com/user-attachments/assets/0b60f8e9-780e-4cfe-bff8-5d2a00837230)
![New display of option tooltips with improved spacing](https://github.com/user-attachments/assets/66aa65ec-69cb-4bda-8203-f6dde313bfdb)
